### PR TITLE
fix(payments): :bug: Requisition sanitation

### DIFF
--- a/prisma/migrations/20240309012947_/migration.sql
+++ b/prisma/migrations/20240309012947_/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX "Transaction_gaverId_receiverId_key";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -43,5 +43,4 @@ model Transaction {
   value      Float    @db.DoublePrecision()
   createdAt  DateTime @default(now()) @db.Timestamp()
 
-  @@unique([gaverId, receiverId])
 }

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,2 +1,3 @@
 export * from './user.errors';
 export * from './auth.errors';
+export * from './payment.errors';

--- a/src/errors/payment.errors.ts
+++ b/src/errors/payment.errors.ts
@@ -1,0 +1,10 @@
+import { AplicationError } from "@/types";
+import httpStatus from "http-status";
+
+export function DoubleData(): AplicationError {
+    return {
+        status: httpStatus.UNPROCESSABLE_ENTITY,
+        message: "Only receiver email or nick, not both",
+        name: "Double data"
+    }
+}

--- a/src/helpers/checkers.ts
+++ b/src/helpers/checkers.ts
@@ -1,0 +1,3 @@
+export function checkValidData(data: any): boolean {
+    return ((data !== undefined) && (data !== null));
+}

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,0 +1,1 @@
+export * from './checkers'

--- a/src/services/payments.ts
+++ b/src/services/payments.ts
@@ -1,14 +1,29 @@
 import { exchange, getUserByEmail, getUserByNick } from "@/repositories";
 import { PaymentParams } from "@/types";
 import { validateSession } from "@/middlewares";
+import { DoubleData } from "@/errors";
+import { checkValidData } from "@/helpers";
 
 export async function sendMoney(payment: PaymentParams) {
     const session = await validateSession(payment.authorization);
 
-    const { id: receiverId } = payment.receiverNick ?
+    checkDoubleData(payment);
+
+    const { id: receiverId } = checkValidData(payment.receiverNick) ?
         await getUserByNick(payment.receiverNick) :
         await getUserByEmail(payment.receiverEmail);
 
 
     return await exchange({ gaverId: session.User.id, receiverId, value: payment.value });
 };
+
+function checkDoubleData(payment: PaymentParams) {
+    const { receiverEmail, receiverNick } = payment;
+
+    const emailIsValid = checkValidData(receiverEmail);
+    const nickIsValid = checkValidData(receiverNick);
+
+    if (emailIsValid && nickIsValid) throw DoubleData()
+};
+
+


### PR DESCRIPTION
User can only send payment requisitions with the receiver nick or email, but not both. Decision was taken to prevent errors.

data processment, payment requisition